### PR TITLE
Fix/23 seed hashing only

### DIFF
--- a/college-management/Dados/CredenciaisUsuario.cs
+++ b/college-management/Dados/CredenciaisUsuario.cs
@@ -1,9 +1,4 @@
 ﻿using college_management.Utilitarios;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace college_management.Dados;
 
@@ -18,21 +13,9 @@ public class CredenciaisUsuario
         Senha = senha.Length >= 64 ? senha : UtilitarioCriptografia.CriptografarSha256(senha, sal);
     }
 
-    public static CredenciaisUsuario? TryParse(string input)
-    {
-        if (string.IsNullOrEmpty(input))
-            return null;
-
-        var split = input.Split('+', 2);
-        if (split.Length <= 1) return null;
-
-        (string senha, string sal) = (split[0], split[1]);
-        return new CredenciaisUsuario(senha, sal);
-    }
-
     public bool Validar(string senha)
     {
-        return Utilitarios.UtilitarioCriptografia.CriptografarSha256(senha, Sal) == Senha;
+        return UtilitarioCriptografia.CriptografarSha256(senha, Sal) == Senha;
     }
 
     public override string ToString()

--- a/college-management/Dados/CredenciaisUsuario.cs
+++ b/college-management/Dados/CredenciaisUsuario.cs
@@ -1,0 +1,42 @@
+﻿using college_management.Utilitarios;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace college_management.Dados;
+
+public class CredenciaisUsuario
+{
+    public string Senha { get; set; }
+    public string Sal { get; set; }
+
+    public CredenciaisUsuario(string senha, string? sal = null)
+    {
+        Senha = senha;
+        Sal = sal ?? Utilitarios.UtilitarioCriptografia.GerarSal();
+    }
+
+    public static CredenciaisUsuario? TryParse(string input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return null;
+
+        var split = input.Split('+', 2);
+        if (split.Length <= 1) return null;
+
+        (string senha, string sal) = (split[0], split[1]);
+        return new CredenciaisUsuario(senha, sal);
+    }
+
+    public bool Validar(string senha)
+    {
+        return Utilitarios.UtilitarioCriptografia.CriptografarSha256(senha, Sal) == Senha;
+    }
+
+    public override string ToString()
+    {
+        return $"{Senha}+{Sal}";
+    }
+}

--- a/college-management/Dados/CredenciaisUsuario.cs
+++ b/college-management/Dados/CredenciaisUsuario.cs
@@ -10,12 +10,12 @@ namespace college_management.Dados;
 public class CredenciaisUsuario
 {
     public string Senha { get; set; }
-    public string Sal { get; set; }
+    public string Sal   { get; set; }
 
     public CredenciaisUsuario(string senha, string? sal = null)
     {
-        Senha = senha;
-        Sal = sal ?? Utilitarios.UtilitarioCriptografia.GerarSal();
+        Sal = sal ?? UtilitarioCriptografia.GerarSal();
+        Senha = senha.Length >= 64 ? senha : UtilitarioCriptografia.CriptografarSha256(senha, sal);
     }
 
     public static CredenciaisUsuario? TryParse(string input)

--- a/college-management/Dados/Modelos/Usuario.cs
+++ b/college-management/Dados/Modelos/Usuario.cs
@@ -1,43 +1,7 @@
 using System.Globalization;
 using System.Text.Json.Serialization;
 using college_management.Dados.Repositorios;
-
-
 namespace college_management.Dados.Modelos;
-
-public class CredenciaisUsuario
-{
-	public string Senha { get; set; }
-	public string Sal   { get; set; }
-	
-	public CredenciaisUsuario(string senha, string? sal = null)
-	{
-		Senha = senha;
-		Sal = sal ?? Utilitarios.UtilitarioCriptografia.GerarSal();
-	}
-
-	public static CredenciaisUsuario? TryParse(string input)
-	{
-		if (string.IsNullOrEmpty(input))
-			return null;
-
-		var split = input.Split('+', 2);
-		if (split.Length <= 1) return null;
-
-		(string senha, string sal) = (split[0], split[1]);
-		return new CredenciaisUsuario(senha, sal);
-	}
-
-	public bool Validar(string senha)
-	{
-        return Utilitarios.UtilitarioCriptografia.CriptografarSha256(senha, Sal) == Senha;
-	}
-
-	public override string ToString()
-	{
-		return $"{Senha}+{Sal}";
-	}
-}
 
 [JsonDerivedType(typeof(Usuario), "base")]
 [JsonDerivedType(typeof(Aluno), "aluno")]

--- a/college-management/Program.cs
+++ b/college-management/Program.cs
@@ -3,7 +3,7 @@ using college_management.Middlewares;
 using college_management.Utilitarios;
 
 
-UtilitarioArquivos.Incializar();
+UtilitarioArquivos.Inicializar();
 
 BaseDeDados baseDeDados = new();
 

--- a/college-management/Utilitarios/UtilitarioArquivos.cs
+++ b/college-management/Utilitarios/UtilitarioArquivos.cs
@@ -16,7 +16,7 @@ public static class UtilitarioArquivos
 	public static readonly string DiretorioLayouts =
 		Path.Combine(DiretorioBase, "Layouts");
 
-	public static void Incializar()
+	public static void Inicializar()
 	{
 		string[] diretorios =
 			[DiretorioBase, DiretorioDados, DiretorioLayouts];

--- a/college-management/Utilitarios/UtilitarioSeed.cs
+++ b/college-management/Utilitarios/UtilitarioSeed.cs
@@ -88,9 +88,6 @@ public static class UtilitarioSeed
 		    .Variaveis
 		    .TryGetValue(senha, out var senhaDefault);
 
-		var sal = UtilitarioCriptografia.GerarSal();
-        CredenciaisUsuario credenciais = new(UtilitarioCriptografia.CriptografarSha256(senhaDefault, sal), sal);
-
-        return (loginDefault, nomeDefault, credenciais);
+        return (loginDefault, nomeDefault, new(senhaDefault));
 	}
 }


### PR DESCRIPTION
Correções em relação ao hash, que agora é aplicado automaticamente e obrigatoriamente a qualquer senha menor que 64 caracteres, dentro do próprio construtor de ``CredenciaisUsuario``.
Outras mudanças incluem:

- ``CredenciaisUsuario`` agora está em seu próprio arquivo.
- Na inicialização Seed [UtilitarioSeed.cs:91](https://github.com/os-derivados/college-management/compare/fix/23-seed-hashing-only?expand=1#diff-38ab534ccf0fa127a0c471b1927ac9e6d608cab62f0922b1983c00cdc9a96ec6), a inicialização das credenciais é feita de forma implícita.
- Uma pequena correção no nome da função [``UtilitarioArquivos.Inicializar()``](https://github.com/os-derivados/college-management/compare/fix/23-seed-hashing-only?expand=1#diff-83616925226374dc3c6cbe9c95f1c9b3edd1576adec228310b00ef0ae3c52f65).