### PR TITLE
fix: (#27) propriedades vazias tratadas corretamente

### DIFF
--- a/college-management/Utilitarios/UtilitarioTipos.cs
+++ b/college-management/Utilitarios/UtilitarioTipos.cs
@@ -28,9 +28,9 @@ public static class UtilitarioTipos
 		foreach (var nome in nomesPropriedades)
 		{
 			var propriedade = tipoModelo.GetProperty(nome);
-			var valor       = propriedade.GetValue(modelo);
+ 			var valor       = propriedade?.GetValue(modelo)?.ToString() ?? string.Empty;
 
-			resultado.Add(nome, valor.ToString());
+			resultado.Add(nome, valor);
 		}
 
 		return resultado;


### PR DESCRIPTION
Propriedades vazias agora são tratadas corretamente, com valores nulos convertidos para uma string vazia, evitando uma ``NullReferenceException``.