### PR TITLE
fix: (#35) utilizando valor correto na criação do hash

### DIFF
--- a/college-management/Dados/CredenciaisUsuario.cs
+++ b/college-management/Dados/CredenciaisUsuario.cs
@@ -10,7 +10,7 @@ public class CredenciaisUsuario
     public CredenciaisUsuario(string senha, string? sal = null)
     {
         Sal = sal ?? UtilitarioCriptografia.GerarSal();
-        Senha = senha.Length >= 64 ? senha : UtilitarioCriptografia.CriptografarSha256(senha, sal);
+        Senha = senha.Length >= 64 ? senha : UtilitarioCriptografia.CriptografarSha256(senha, Sal);
     }
 
     public bool Validar(string senha)


### PR DESCRIPTION
#35 corrigido.

- Construtor de ``CredenciaisUsuario`` agora usa o valor corrento invés do parâmetro do mesmo.

Observação: como @trsaints apontou, ``ContextoUsuarios``, ``UtilitarioSeed`` e ``RepositorioUsuarios`` também deveriam ser verificados em busca de erros ou descuidos na autenticação de usuários.