### PR TITLE
Verifica se o usuário foi criado com sucesso antes de prosseguir

### DIFF
--- a/college-management/Utilitarios/UtilitarioSeed.cs
+++ b/college-management/Utilitarios/UtilitarioSeed.cs
@@ -59,7 +59,8 @@ public static class UtilitarioSeed
 		                           cargoAluno.Id,
 		                           matriculaTeste.Id);
 
-		await baseDeDados.Usuarios.Adicionar(alunoTeste);
+		var alunoCriado = await baseDeDados.Usuarios.Adicionar(alunoTeste);
+		if(!alunoCriado) return;
 
 		matriculaTeste.AlunoId = alunoTeste.Id;
 		matriculaTeste.CursoId = cursoTeste.Id;


### PR DESCRIPTION
O utilitário da seed estava adicionando novas matriculas no banco mesmo que a criação do usuário houvesse falhado (por duplicidade). Adicionei uma verificação simples para garantir que novas matriculas sejam adicionadas no banco apenas se a criação do usuário for bem sucessida.