### PR TITLE
Corrigindoerro ao selecionar a opcao de sair nos submenus depois de selecionado uma das opções iniciais e alterando variável para tipagem estática

### DIFF
--- a/college-management/Middlewares/MiddlewareContexto.cs
+++ b/college-management/Middlewares/MiddlewareContexto.cs
@@ -63,7 +63,7 @@ public static class MiddlewareContexto
 
 			var opcaoEscolhida = Console.ReadKey();
 
-			if (opcaoEscolhida.Key is not ConsoleKey.D0)
+			if (opcaoEscolhida.Key > ConsoleKey.D0 && opcaoEscolhida.Key <= ConsoleKey.D9)
 			{
 				var recursoEscolhido =
 					ConverterParaMetodo(contexto,
@@ -74,6 +74,7 @@ public static class MiddlewareContexto
 				contexto.AcessarRecurso(recursoEscolhido);
 			}
 			else
+if(opcaoEscolhida.Key == ConsoleKey.D0)
 			{
 				estadoAtual = EstadoDoApp.Sair;
 			}

--- a/college-management/Middlewares/MiddlewareContexto.cs
+++ b/college-management/Middlewares/MiddlewareContexto.cs
@@ -61,7 +61,7 @@ public static class MiddlewareContexto
 
 			contexto.ListarOpcoes();
 
-			var opcaoEscolhida = Console.ReadKey();
+			ConsoleKeyInfo opcaoEscolhida = Console.ReadKey();
 
 			if (opcaoEscolhida.Key > ConsoleKey.D0 && opcaoEscolhida.Key <= ConsoleKey.D9)
 			{


### PR DESCRIPTION
Fiz a correção da issue 55, modificando as verificações no arquivo MiddlewareContexto.cs para não enviar para o método que escolhe o contexto se a opção digitada não for um número, bem como alterei a variável opcaoEscolhida para tipagem estática já que o método Console.Read sempre retorna um ConsoleKeyInfo.