### PR TITLE
[Curso] Evitar exceção com grade curricular nula

### DIFF
--- a/college-management/Dados/Modelos/Curso.cs
+++ b/college-management/Dados/Modelos/Curso.cs
@@ -25,7 +25,7 @@ public class Curso : Modelo
 	{
 		return
 			$"| {Nome,-16} "
-			+ $"| {GradeCurricular.Length + " Matéria(s)",-16} "
+			+ $"| {(GradeCurricular ?? []).Length + " Matéria(s)",-16} "
 			+ $"| {(MatriculasIds?.Count ?? 0) + " Matrícula(s)",-16} "
 			+ $"| {Id,-16} |";
 	}


### PR DESCRIPTION
No método sobrecarregado ``ToString()`` do modelo ``Curso``, caso a grade curricular da entidade seja nula, o programa jogava uma exceção e terminava. Esta PR corrige este bug.